### PR TITLE
Sync QEMU invocation with Solo5

### DIFF
--- a/src/runner.c
+++ b/src/runner.c
@@ -453,9 +453,12 @@ int main(int argc, char *argv[])
      */
     if (hypervisor == QEMU || hypervisor == KVM) {
         pvadd(uargpv, "/usr/bin/qemu-system-x86_64");
-        pvadd(uargpv, "-vga");
+        pvadd(uargpv, "-nodefaults");
+        pvadd(uargpv, "-no-acpi");
+        pvadd(uargpv, "-display");
         pvadd(uargpv, "none");
-        pvadd(uargpv, "-nographic");
+        pvadd(uargpv, "-serial");
+        pvadd(uargpv, "stdio");
         pvadd(uargpv, "-m");
         pvadd(uargpv, "512");
         if (hypervisor == KVM) {
@@ -468,7 +471,7 @@ int main(int argc, char *argv[])
              * Required for AESNI use in Mirage.
              */
             pvadd(uargpv, "-cpu");
-            pvadd(uargpv, "Broadwell");
+            pvadd(uargpv, "Westmere");
         }
         pvadd(uargpv, "-device");
         char *guest_mac = generate_mac();


### PR DESCRIPTION
Use the same QEMU invocation parameters as 'solo5-run-virtio.sh'.

The user-visible change here is that we disable the QEMU monitor on the
console, so QEMU/KVM unikernels run in interactive mode can be
terminated with ^C.